### PR TITLE
Docs Command and several other template improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
+  - nightly
 
 install:
   - composer install --prefer-dist

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ phint init project-name --config phint.json
 
 ## Commands
 
+Each of the commands below should be used like so:
+```sh
+cd /path/to/project
+phint <command> [--options] [args]
+```
+
 ### init
 
 > alias i
@@ -154,16 +160,11 @@ Update Phint to lastest version or rollback to earlier locally installed version
 ***Parameters:***
 
 ```
-Arguments:
-  (n/a)
-
 Options:
   [-h|--help]         Show help
   [-r|--rollback]     Rollback to earlier version
   [-v|--verbosity]    Verbosity level
   [-V|--version]      Show version
-
-Legend: <required> [optional] variadic...
 
 Usage Examples:
   phint update        Updates to latest version
@@ -177,18 +178,19 @@ Usage Examples:
 > alias t
 
 Generate test files with proper classes and test methods analogous to their source counterparts.
+If a test class already exists, it is skipped. In future we may append test stubs for new methods.
+
+Ideally you would run it on existing project **or** after you create/update `src/` files.
 
 ***Parameters:***
 
 ```
-Arguments:
-  (n/a)
-
 Options:
   [-a|--with-abstract]    Create stub for abstract/interface class
   [-d|--dump-autoload]    Force composer dumpautoload (slow)
   [-h|--help]             Show help
-  [-n|--naming]           Test method naming format [t: testMethod | m: test_method | i: it_tests_]
+  [-n|--naming]           Test method naming format
+                          (t: testMethod | m: test_method | i: it_tests_)
   [-p|--phpunit]          Base PHPUnit class to extend from
   [-s|--no-setup]         Dont add setup method
   [-t|--no-teardown]      Dont add teardown method
@@ -201,11 +203,37 @@ Usage Examples:
   phint test -a          With stubs for abstract/interface
 ```
 
+## docs
+
+> alias d
+
+Generate docs (`.md`) for all public classes and methods from their docblocks.
+
+Ideally you would run it on existing project **or** after you create/update `src/` files.
+
+***Parameters:***
+
+```
+Options:
+  [-a|--with-abstract]    Create docs for abstract/interface class
+  [-h|--help]             Show help
+  [-o|--output]           Output file (default README.md). For old project you should use something else
+                          (OR mark region with <!-- DOCS START --> and <!-- DOCS END --> to inject docs)
+  [-v|--verbosity]        Verbosity level
+  [-V|--version]          Show version
+
+Usage Examples:
+  phint docs               If there is `<!-- DOCS START -->` and `<!-- DOCS END -->` region
+                           Injects new doc in between them otherwise appends to bottom
+  phint d -o docs/api.md   Writes to docs/api.md (Same rule applies regarding inject/append)
+```
+
 
 ## Todo
 
 Including but not limited to:
 
-- [ ] Readme.md generator
+- [x] README.md/Docs generator
 - [x] Test files generator
-- [ ] Specify template path (with fallback to current)
+- [ ] Support user templates
+- [ ] Test stubs for new methods

--- a/bin/phint
+++ b/bin/phint
@@ -38,9 +38,10 @@ $app = new Ahc\Cli\Application(
     \trim(\file_get_contents(__DIR__ . '/../VERSION'))
 );
 
-// Aliased as `i`
+// Add commands and their aliases
 $app->add(new Ahc\Phint\Console\InitCommand,   'i');
 $app->add(new Ahc\Phint\Console\UpdateCommand, 'u');
 $app->add(new Ahc\Phint\Console\TestCommand,   't');
+$app->add(new Ahc\Phint\Console\DocsCommand,   'd');
 
 $app->logo($logo)->handle($_SERVER['argv']);

--- a/composer.json
+++ b/composer.json
@@ -42,11 +42,5 @@
         }
     },
     "scripts": {
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/crazyfactory/php-docblocks"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "adhocore/cli": "^0.2",
         "adhocore/json-comment": "^0.0.3",
         "crazyfactory/docblocks": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "php": ">=7.0",
         "adhocore/cli": "^0.2",
         "adhocore/json-comment": "^0.0.3",
+        "crazyfactory/docblocks": "^2.2",
         "symfony/process": "^3.3.0",
         "symfony/finder": "^3.3.0",
         "twig/twig":  "^2.4.0"
@@ -41,5 +42,11 @@
         }
     },
     "scripts": {
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/crazyfactory/php-docblocks"
+        }
+    ]
 }

--- a/resources/CONTRIBUTING.md.twig
+++ b/resources/CONTRIBUTING.md.twig
@@ -13,7 +13,10 @@ You may need to fork this project in [GitHub](https://github.com/{{username}}/{{
 git clone git@github.com:{{username}}/{{project}}.git
 
 # OR if you have a fork
-# git clone git@github.com:<your_github_handle>/{{project}}.git
+git clone git@github.com:<your_github_handle>/{{project}}.git
+
+# You may also add upstream
+git remote add upstream https://github.com/{{username}}/{{project}}.git
 
 cd {{project}}
 
@@ -39,6 +42,11 @@ for P in src tests; do find $P -type f -name '*.php' -exec php -l {} \;; done
 
 # Run tests
 vendor/bin/phpunit --coverage-text
+
+
+# If your feature takes long your dev branch might be out of sync, you may want to
+git checkout $branch_name
+git pull upstream master # branch could be something else than master
 ```
 
 ### Finalizing
@@ -58,6 +66,8 @@ Now goto [GitHub](https://github.com/{{username}}/{{project}}/compare?expand=1),
 
 ### Getting PR merged
 
-You have to wait. You have to address change requests.
+You have to wait. You have to address change requests. Be patient.
 
 Thank you for contribution!
+
+**Lastly** Please be informed that your works will be licensed same as the project [license](./LICENSE)

--- a/resources/README.md.twig
+++ b/resources/README.md.twig
@@ -31,3 +31,12 @@ use {{namespace}};
 
 <!-- DOCS START -->
 <!-- DOCS END -->
+
+## Contributing
+
+Please check [the guide](./CONTRIBUTING.md)
+
+## LICENSE
+
+{% set L = {'m': 'MIT', 'g': 'GNU LGPL', 'a': 'Apache 2', 'b': 'BSD Simple', 'i': 'ISC'} %}
+> &copy; [{{L[license]}}](./LICENSE) | {{year}}, {{name}}

--- a/resources/README.md.twig
+++ b/resources/README.md.twig
@@ -26,3 +26,8 @@ composer require {{username}}/{{package}}
 use {{namespace}};
 
 ```
+
+## API
+
+<!-- DOCS START -->
+<!-- DOCS END -->

--- a/resources/docs/ISSUE_TEMPLATE.md.twig
+++ b/resources/docs/ISSUE_TEMPLATE.md.twig
@@ -1,7 +1,8 @@
-## This is a
+## Introduction
 
-<-- Put a cross `x` in one of the below boxes -->
+**This is a**
 
+<!-- Put a cross `x` in one of the below boxes -->
 - [ ] Bug/Issue
 - [ ] Feature request
 - [ ] General stuff

--- a/resources/docs/PULL_REQUEST_TEMPLATE.md.twig
+++ b/resources/docs/PULL_REQUEST_TEMPLATE.md.twig
@@ -1,7 +1,8 @@
-## This is a
+## Introduction
 
-<-- Put a cross `x` in relevant boxes below -->
+**This is a**
 
+<!-- Put a cross `x` in relevant boxes below -->
 - [ ] New feature
 - [ ] Fix for ... <!-- (the issue/bug) -->
 - [ ] General improvement

--- a/resources/docs/docs.twig
+++ b/resources/docs/docs.twig
@@ -1,0 +1,31 @@
+{% for class in docsMetadata %}
+## {{class.name}}
+
+```php
+use {{class.classFqcn}};
+```
+{% if class.title %}
+
+> {{class.title}}
+{% endif %}
+{% if class.texts %}
+
+{{class.texts|join("\n")}}
+{% endif %}
+{% for name, method in class.methods %}
+### {{name}}()
+{% if method.title %}
+
+> {{method.title}}
+{% endif %}
+
+```php
+{{method.static ? '::' : '->'}}{{name}}({{method.params|join(', ')}}){{method.return ? ': ' ~ method.return : ''}}
+```
+{% if method.texts %}
+
+{{method.texts|join("\n")|replace({'<code>':"```php",'</code>':"```"})|raw}}
+{% endif %}
+{% endfor %}
+
+{% endfor %}

--- a/resources/docs/docs.twig
+++ b/resources/docs/docs.twig
@@ -20,7 +20,7 @@ use {{class.classFqcn}};
 {% endif %}
 
 ```php
-{{method.static ? '::' : '->'}}{{name}}({{method.params|join(', ')}}){{method.return ? ': ' ~ method.return : ''}}
+{{name}}({{method.params|join(', ')}}){{method.return ? ': ' ~ method.return : ''}}
 ```
 {% if method.texts %}
 

--- a/resources/docs/docs.twig
+++ b/resources/docs/docs.twig
@@ -20,7 +20,7 @@ use {{class.classFqcn}};
 {% endif %}
 
 ```php
-{{name}}({{method.params|join(', ')}}){{method.return ? ': ' ~ method.return : ''}}
+{{method.static ? '::' : ''}}{{name}}({{method.params|join(', ')}}){{method.return ? ': ' ~ method.return : ''}}
 ```
 {% if method.texts %}
 

--- a/resources/tests/test.twig
+++ b/resources/tests/test.twig
@@ -35,7 +35,7 @@ class Test{{className}} extends {{className}}
  */
 class {{className}}Test extends TestCase
 {
-{% if newable or special %}
+{% if (newable or special) and setup %}
     /**
      * @var {{ special ? 'Test' : ''}}{{className}}
      */
@@ -62,7 +62,7 @@ class {{className}}Test extends TestCase
 {% for method, attr in methods if not attr.abstract %}
 
 {% if naming == 't' %}
-    public function test{{method|capitalize}}()
+    public function test{{method|ucfirst}}()
 {% elseif naming == 'm' %}
     public function test_{{method|snake}}()
 {% elseif naming == 'i' %}
@@ -73,12 +73,16 @@ class {{className}}Test extends TestCase
 {% endif %}
     {
 {% if attr.static %}
-        {{className}}::{{method}}();
+        $actual = {{className}}::{{method}}();
+{% elseif setup %}
+        $actual = $this->{{className|lcfirst}}->{{method}}();
 {% else %}
-        $this->{{className|lcfirst}}->{{method}}();
+        ${{className|lcfirst}} = new {{ special ? 'Test' : ''}}{{className}};
+
+        $actual = ${{className|lcfirst}}->{{method}}();
 {% endif %}
 
-        // $this->assert
+        // $this->assertSame('', $actual);
     }
 {% endfor %}
 }

--- a/src/Console/DocsCommand.php
+++ b/src/Console/DocsCommand.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Ahc\Phint\Console;
+
+use Ahc\Cli\IO\Interactor;
+use Ahc\Phint\Generator\TwigGenerator;
+use Ahc\Phint\Util\Composer;
+
+class DocsCommand extends BaseCommand
+{
+    /** @var string Command name */
+    protected $_name = 'docs';
+
+    /** @var string Command description */
+    protected $_desc = 'Generate basic readme docs from docblocks';
+
+    /** @var string Current working dir */
+    protected $_workDir;
+
+    /**
+     * Configure the command options/arguments.
+     *
+     * @return void
+     */
+    protected function onConstruct()
+    {
+        $this->_workDir  = \realpath(\getcwd());
+
+        $this
+            ->option('-o --output', "Output file (default README.md)\nFor old project you should use something else")
+            ->option('-a --with-abstract', 'Create stub for abstract/interface class')
+            ->usage(
+                '<bold>  phint docs</end>               Appends to readme.md<eol/>' .
+                '<bold>  phint d</end> <comment>-o docs/api.md</end>   Writes to docs/api.md<eol/>'
+            );
+    }
+
+    /**
+     * Generate test stubs.
+     *
+     * @return void
+     */
+    public function execute()
+    {
+        $io = $this->app()->io();
+
+        $io->comment('Preparing metadata ...', true);
+        $metadata = $this->prepare();
+
+        if (empty($metadata)) {
+            $io->bgGreen('Looks like nothing to do here', true);
+
+            return;
+        }
+
+        $io->comment('Generating tests ...', true);
+        $generated = $this->generate($metadata);
+
+        if ($generated) {
+            $io->cyan("$generated test(s) generated", true);
+        }
+
+        $io->ok('Done', true);
+    }
+
+    protected function prepare(): array
+    {
+        // Sorry psr-0!
+        $namespaces = $this->_composer->config('autoload.psr-4');
+
+        $srcPaths = [];
+        foreach ($namespaces as $ns => $path) {
+            if (\preg_match('!^(source|src|lib|class)/?!', $path)) {
+                $srcPaths[] = $path;
+            }
+        }
+
+        $classes = $this->_pathUtil->loadClasses($srcPaths);
+
+        return $this->getClassesMetadata($classes);
+    }
+
+    protected function getClassesMetadata(array $classes): array
+    {
+        $metadata = [];
+
+        foreach ($classes as $classFqcn) {
+            if ([] === $meta = $this->getClassMetadata($classFqcn)) {
+                continue;
+            }
+
+            $metadata[] = $meta;
+        }
+
+        return $metadata;
+    }
+
+    protected function getClassMetadata(string $classFqcn): array
+    {
+        $reflex = new \ReflectionClass($classFqcn);
+
+        if (!$this->shouldGenerateDocs($reflex)) {
+            return [];
+        }
+
+        $methods     = [];
+        $isTrait     = $reflex->isTrait();
+        $isAbstract  = $reflex->isAbstract();
+        $isInterface = $reflex->isInterface();
+
+        foreach ($reflex->getMethods(\ReflectionMethod::IS_PUBLIC) as $m) {
+            if ($m->class !== $classFqcn) {
+                continue;
+            }
+
+            $methods[$m->name] = $this->getMethodMetadata($m);
+        }
+
+        if (empty($methods)) {
+            return [];
+        }
+
+        return \compact('classFqcn', 'isTrait', 'isAbstract', 'isInterface', 'methods');
+    }
+
+    protected function shouldGenerateDocs(\ReflectionClass $reflex): bool
+    {
+        if ($this->abstract) {
+            return true;
+        }
+
+        return !$reflex->isInterface() && !$reflex->isAbstract();
+    }
+
+    protected function getMethodMetadata(\ReflectionMethod $method): array
+    {
+        $args = [];
+
+        return ['static' => $method->isStatic(), 'abstract' => $method->isAbstract(), 'args' => $args];
+    }
+
+    protected function generate(array $metadata): int
+    {
+        $templatePath = __DIR__ . '/../../resources';
+        $generator    = new TwigGenerator($templatePath, $this->getCachePath());
+
+        return $generator->generateDocs($metadata, $this->values());
+    }
+}

--- a/src/Console/DocsCommand.php
+++ b/src/Console/DocsCommand.php
@@ -1,10 +1,17 @@
 <?php
 
+/*
+ * This file is part of the PHINT package.
+ *
+ * (c) Jitendra Adhikari <jiten.adhikary@gmail.com>
+ *     <https://github.com/adhocore>
+ *
+ * Licensed under MIT license.
+ */
+
 namespace Ahc\Phint\Console;
 
-use Ahc\Cli\IO\Interactor;
 use Ahc\Phint\Generator\TwigGenerator;
-use Ahc\Phint\Util\Composer;
 
 class DocsCommand extends BaseCommand
 {

--- a/src/Console/DocsCommand.php
+++ b/src/Console/DocsCommand.php
@@ -155,7 +155,7 @@ class DocsCommand extends BaseCommand
         }
 
         if (null !== $return = $parser->first('return')) {
-            $return = \preg_replace(['/(.*\$\w+)(.*)/', '/ +/'], ['$1', ' '], $return->getValue());
+            $return = \preg_replace('/ .*?$/', '', $return->getValue());
         }
 
         $texts = $parser->texts();

--- a/src/Console/DocsCommand.php
+++ b/src/Console/DocsCommand.php
@@ -36,7 +36,10 @@ class DocsCommand extends BaseCommand
         $this->_workDir  = \realpath(\getcwd());
 
         $this
-            ->option('-o --output', "Output file (default README.md)\nFor old project you should use something else")
+            ->option('-o --output', 'Output file (default README.md). For old project you should use something else'
+                ."\n(OR mark region with <!-- DOCS START --> and <!-- DOCS END --> to inject docs)",
+                null, 'README.md'
+            )
             ->option('-a --with-abstract', 'Create stub for abstract/interface class')
             ->usage(
                 '<bold>  phint docs</end>               Appends to readme.md<eol/>' .
@@ -63,7 +66,7 @@ class DocsCommand extends BaseCommand
         }
 
         $io->comment('Generating docs ...', true);
-        $generated = $this->generate($docsMetadata);
+        $generated = $this->generate($docsMetadata, $this->values());
 
         if ($generated) {
             $io->cyan("$generated doc(s) generated", true);
@@ -164,11 +167,15 @@ class DocsCommand extends BaseCommand
         return ['static' => $method->isStatic()] + \compact('title', 'texts', 'params', 'return');
     }
 
-    protected function generate(array $docsMetadata): int
+    protected function generate(array $docsMetadata, array $parameters): int
     {
         $templatePath = __DIR__ . '/../../resources';
         $generator    = new TwigGenerator($templatePath, $this->getCachePath());
 
-        return $generator->generateDocs($docsMetadata, $this->values());
+        if (!$this->_pathUtil->isAbsolute($parameters['output'])) {
+            $parameters['output'] = $this->_pathUtil->join($this->_workDir, $parameters['output']);
+        }
+
+        return $generator->generateDocs($docsMetadata, $parameters);
     }
 }

--- a/src/Console/DocsCommand.php
+++ b/src/Console/DocsCommand.php
@@ -12,7 +12,6 @@
 namespace Ahc\Phint\Console;
 
 use Ahc\Phint\Generator\TwigGenerator;
-use Ahc\Phint\Util\Composer;
 use CrazyFactory\DocBlocks\DocBlock;
 
 class DocsCommand extends BaseCommand
@@ -37,7 +36,7 @@ class DocsCommand extends BaseCommand
 
         $this
             ->option('-o --output', 'Output file (default README.md). For old project you should use something else'
-                ."\n(OR mark region with <!-- DOCS START --> and <!-- DOCS END --> to inject docs)",
+                . "\n(OR mark region with <!-- DOCS START --> and <!-- DOCS END --> to inject docs)",
                 null, 'README.md'
             )
             ->option('-a --with-abstract', 'Create stub for abstract/interface class')

--- a/src/Console/DocsCommand.php
+++ b/src/Console/DocsCommand.php
@@ -39,7 +39,7 @@ class DocsCommand extends BaseCommand
                 . "\n(OR mark region with <!-- DOCS START --> and <!-- DOCS END --> to inject docs)",
                 null, 'README.md'
             )
-            ->option('-a --with-abstract', 'Create stub for abstract/interface class')
+            ->option('-a --with-abstract', 'Create docs for abstract/interface class')
             ->usage(
                 '<bold>  phint docs</end>               Appends to readme.md<eol/>' .
                 '<bold>  phint d</end> <comment>-o docs/api.md</end>   Writes to docs/api.md<eol/>'

--- a/src/Console/DocsCommand.php
+++ b/src/Console/DocsCommand.php
@@ -120,9 +120,10 @@ class DocsCommand extends BaseCommand
         $methods = [];
         $isTrait = $reflex->isTrait();
         $name    = $reflex->getShortName();
+        $exclude = ['__construct', '__destruct'];
 
         foreach ($reflex->getMethods(\ReflectionMethod::IS_PUBLIC) as $m) {
-            if ($m->class !== $classFqcn) {
+            if ($m->class !== $classFqcn && \in_array($m->name, $exclude)) {
                 continue;
             }
 

--- a/src/Console/TestCommand.php
+++ b/src/Console/TestCommand.php
@@ -38,7 +38,7 @@ class TestCommand extends BaseCommand
         $this
             ->option('-t --no-teardown', 'Dont add teardown method')
             ->option('-s --no-setup', 'Dont add setup method')
-            ->option('-n --naming', 'Test method naming format')
+            ->option('-n --naming', "Test method naming format\n(t: testMethod | m: test_method | i: it_tests_)")
             ->option('-a --with-abstract', 'Create stub for abstract/interface class')
             ->option('-p --phpunit [classFqcn]', 'Base PHPUnit class to extend from')
             ->option('-d --dump-autoload', 'Force composer dumpautoload (slow)', null, false)

--- a/src/Generator/CollisionHandler.php
+++ b/src/Generator/CollisionHandler.php
@@ -24,30 +24,30 @@ class CollisionHandler implements CollisionHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(string $targetFile, string $newContent, array $parameters = null)
+    public function handle(string $targetFile, string $newContent, array $parameters = null): bool
     {
         switch ($this->pathUtil->getExtension($targetFile)) {
             case 'json':
-                $this->mergeJson($targetFile, $newContent);
-                break;
+                return $this->mergeJson($targetFile, $newContent);
 
             case 'md':
-                $this->appendFile($targetFile, "\n---\n" . $newContent);
-                break;
+               return $this->appendFile($targetFile, "\n---\n" . $newContent);
         }
+
+        return false;
     }
 
-    protected function mergeJson(string $targetFile, string $newContent)
+    protected function mergeJson(string $targetFile, string $newContent): bool
     {
         $oldJson = $this->pathUtil->readAsJson($targetFile);
         $newJson = \json_decode($newContent, true);
         $merged  = Arr::mergeRecursive($oldJson, $newJson);
 
-        $this->pathUtil->writeFile($targetFile, $merged);
+        return $this->pathUtil->writeFile($targetFile, $merged);
     }
 
-    protected function appendFile(string $targetFile, string $newContent)
+    protected function appendFile(string $targetFile, string $newContent): bool
     {
-        $this->pathUtil->writeFile($targetFile, $newContent, \FILE_APPEND);
+        return $this->pathUtil->writeFile($targetFile, $newContent, \FILE_APPEND);
     }
 }

--- a/src/Generator/CollisionHandlerInterface.php
+++ b/src/Generator/CollisionHandlerInterface.php
@@ -20,7 +20,7 @@ interface CollisionHandlerInterface
      * @param string $newContent
      * @param array  $parameters
      *
-     * @return void
+     * @return bool
      */
-    public function handle(string $targetFile, string $newContent, array $parameters = null);
+    public function handle(string $targetFile, string $newContent, array $parameters = null): bool;
 }

--- a/src/Generator/GeneratorInterface.php
+++ b/src/Generator/GeneratorInterface.php
@@ -20,7 +20,7 @@ interface GeneratorInterface
      * @param array                     $parameters
      * @param CollisionHandlerInterface $handler    Optional, if not provided files are overwritten.
      *
-     * @return void
+     * @return int The count of generated files.
      */
-    public function generate(string $targetPath, array $parameters, CollisionHandlerInterface $handler = null);
+    public function generate(string $targetPath, array $parameters, CollisionHandlerInterface $handler = null): int;
 }

--- a/src/Generator/TwigGenerator.php
+++ b/src/Generator/TwigGenerator.php
@@ -119,8 +119,16 @@ class TwigGenerator implements GeneratorInterface
             return \lcfirst($x);
         }));
 
+        $this->twig->addFilter(new \Twig_SimpleFilter('ucfirst', function ($x) {
+            return \ucfirst($x);
+        }));
+
         $this->twig->addFunction(new \Twig_Function('gmdate', function ($f = null) {
             return \gmdate($f ?? 'Y-m-d H:i:s');
+        }));
+
+        $this->twig->addFilter(new \Twig_SimpleFilter('call', function ($fn) {
+            return $fn(\array_slice(\func_get_args(), 1));
         }));
     }
 

--- a/src/Generator/TwigGenerator.php
+++ b/src/Generator/TwigGenerator.php
@@ -41,6 +41,7 @@ class TwigGenerator implements GeneratorInterface
     /** @var array Templates only loaded by some specific commands */
     protected $commandTemplates = [
         'test' => true,
+        'docs' => true,
     ];
 
     public function __construct(string $templatePath, string $cachePath)

--- a/src/Generator/TwigGenerator.php
+++ b/src/Generator/TwigGenerator.php
@@ -97,6 +97,29 @@ class TwigGenerator implements GeneratorInterface
         return $generated;
     }
 
+    public function generateDocs(array $docsMetadata, array $parameters): int
+    {
+        if (!$this->twig) {
+            $this->initTwig();
+        }
+
+        $targetFile = $parameters['output'] ?? 'README.md';
+        $docContent = $this->twig->render('docs/docs.twig', \compact('docsMetadata') + $parameters);
+        $docContent = "<!-- DOCS START -->\n$docContent\n<!-- DOCS END -->";
+
+        if (null === $oldContent = $this->pathUtil->read($targetFile)) {
+            return (int) $this->pathUtil->writeFile($targetFile, $docContent);
+        }
+
+        if (\strpos($oldContent, '<!-- DOCS START -->')) {
+            $docContent = \preg_replace('~<!-- DOCS START -->.*?<!-- DOCS END -->~s', $docContent, $oldContent);
+
+            return (int) $this->pathUtil->writeFile($targetFile, $docContent);
+        }
+
+        return (int) $this->pathUtil->appendFile($targetFile, $content);
+    }
+
     protected function initTwig()
     {
         $options = [

--- a/src/Generator/TwigGenerator.php
+++ b/src/Generator/TwigGenerator.php
@@ -13,7 +13,6 @@ namespace Ahc\Phint\Generator;
 
 use Ahc\Phint\Util\Inflector;
 use Ahc\Phint\Util\Path;
-use Symfony\Component\Finder\Finder;
 
 class TwigGenerator implements GeneratorInterface
 {

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -165,9 +165,9 @@ class Path
 }
 
 /**
- * Isolated file require
+ * Isolated file require.
  *
- * @param  string $file
+ * @param string $file
  *
  * @return void
  */

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -118,7 +118,7 @@ class Path
         $len    = \strlen($ext);
 
         $finder->files()->ignoreDotFiles($dotfiles)->filter(function ($file) use ($ext, $len) {
-            return \substr($file, -$len) === $ext);
+            return \substr($file, -$len) === $ext;
         });
 
         foreach ($inPaths as $path) {

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -12,6 +12,7 @@
 namespace Ahc\Phint\Util;
 
 use Ahc\Json\Comment;
+use Symfony\Component\Finder\Finder;
 
 class Path
 {
@@ -108,6 +109,28 @@ class Path
         }
 
         return \implode('/', $paths);
+    }
+
+    public function findFiles(array $inPaths, string $ext, bool $dotfiles = false): array
+    {
+        $finder = new Finder;
+        $ext    = '.' . \ltrim($ext, '.');
+        $len    = \strlen($ext);
+
+        $finder->files()->ignoreDotFiles($dotfiles)->filter(function ($file) use ($ext, $len) {
+            return \substr($file, -$len) === $ext);
+        });
+
+        foreach ($inPaths as $path) {
+            $finder->in($path);
+        }
+
+        $files = [];
+        foreach ($finder as $file) {
+            $files[] = (string) $file;
+        }
+
+        return $files;
     }
 
     protected function initPhintPath()

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -28,7 +28,7 @@ class Path
      */
     public function isAbsolute(string $path): bool
     {
-        if (DIRECTORY_SEPARATOR === '\\') {
+        if (\DIRECTORY_SEPARATOR === '\\') {
             return strpos($path, ':') === 1;
         }
 
@@ -133,6 +133,19 @@ class Path
         return $files;
     }
 
+    public function loadClasses(array $inPaths, string $ext): array
+    {
+        $classes = \array_merge(\get_declared_interfaces(), \get_declared_classes(), \get_declared_traits());
+
+        foreach ($this->findFiles($inPaths) as $file) {
+            _require($file);
+        }
+
+        $newClasses = \array_merge(\get_declared_interfaces(), \get_declared_classes(), \get_declared_traits());
+
+        return \array_diff($newClasses, $classes);
+    }
+
     protected function initPhintPath()
     {
         if (null !== $this->phintPath) {
@@ -149,4 +162,16 @@ class Path
             }
         }
     }
+}
+
+/**
+ * Isolated file require
+ *
+ * @param  string $file
+ *
+ * @return void
+ */
+function _require(string $file)
+{
+    require_once $file;
 }

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -61,7 +61,16 @@ class Path
 
     public function readAsJson(string $filePath, bool $asArray = true)
     {
-        return (new Comment)->decode(\file_get_contents($filePath), $asArray);
+        return (new Comment)->decode($this->read($filePath) ?? 'null', $asArray);
+    }
+
+    public function read(string $filePath): ?string
+    {
+        if (\is_file($filePath)) {
+            return \file_get_contents($filePath);
+        }
+
+        return null;
     }
 
     public function writeFile(string $file, $content, int $mode = null): bool

--- a/tests/Generator/TwigGeneratorTest.php
+++ b/tests/Generator/TwigGeneratorTest.php
@@ -27,6 +27,6 @@ class TwigGeneratorTest extends TestCase
     {
         $twigGenerator = new TwigGenerator(__DIR__ . '/../fixtures/twig', __DIR__ . '/../fixtures/twig_cache');
 
-        $this->assertNull($twigGenerator->generate(__DIR__ . '/../fixtures/twig', []));
+        $this->assertSame(1, $twigGenerator->generate(__DIR__ . '/../fixtures/twig', []));
     }
 }


### PR DESCRIPTION
## This is a

- [x] New feature
- [ ] Fix for ... <!-- (the issue/bug) -->
- [ ] General improvement
- [ ] Backward incompatible change

It closes #32  also closes #40 <!-- (Put the issue number after `#`) -->

## Describe the change

Adds `phint docs` (`phint d`) command ...

## How to use it

...

#### Sample code

```php

```
